### PR TITLE
2014 replicate fix

### DIFF
--- a/cenpy/moe/replicate_table_utils.py
+++ b/cenpy/moe/replicate_table_utils.py
@@ -69,16 +69,8 @@ def read_replicate_file(fname):
     rows are the geographic areas (e.g., tracts or counties or ...).    
     """
 
-    # Tables from 2014 do not have the meta-data on the second and third rows
-    # that tables from all other years have.
-    if "/2014/" in fname and "/140/" in fname:
-        skiprows = None
-    else:
-        skiprows = [1,2]
-
     table = pd.read_csv(
         fname,
-        skiprows=skiprows,
         dtype={
             "TBLID": str,
             "GEOID": str,
@@ -89,6 +81,10 @@ def read_replicate_file(fname):
         },
         encoding="latin-1",
     )
+
+    # Keep only rows that have a GEOID
+    mask = table["GEOID"].notna()
+    table = table[mask]
 
     table.loc[table.ORDER.str.len() == 1, "ORDER"] = (
         "00" + table.loc[table.ORDER.str.len() == 1, "ORDER"]

--- a/cenpy/moe/replicate_table_utils.py
+++ b/cenpy/moe/replicate_table_utils.py
@@ -71,7 +71,7 @@ def read_replicate_file(fname):
 
     # Tables from 2014 do not have the meta-data on the second and third rows
     # that tables from all other years have.
-    if "/2014/" in fname:
+    if "/2014/" in fname and "/140/" in fname:
         skiprows = None
     else:
         skiprows = [1,2]

--- a/cenpy/moe/replicate_table_utils.py
+++ b/cenpy/moe/replicate_table_utils.py
@@ -69,9 +69,16 @@ def read_replicate_file(fname):
     rows are the geographic areas (e.g., tracts or counties or ...).    
     """
 
+    # Tables from 2014 do not have the meta-data on the second and third rows
+    # that tables from all other years have.
+    if "/2014/" in fname:
+        skiprows = None
+    else:
+        skiprows = [1,2]
+
     table = pd.read_csv(
         fname,
-        skiprows=[1, 2],
+        skiprows=skiprows,
         dtype={
             "TBLID": str,
             "GEOID": str,

--- a/cenpy/moe/replicate_table_utils.py
+++ b/cenpy/moe/replicate_table_utils.py
@@ -82,9 +82,8 @@ def read_replicate_file(fname):
         encoding="latin-1",
     )
 
-    # Keep only rows that have a GEOID
-    mask = table["GEOID"].notna()
-    table = table[mask]
+    # Keep only rows that have a GEOID (remove meta-data rows)
+    table = table[table["GEOID"].notna()]
 
     table.loc[table.ORDER.str.len() == 1, "ORDER"] = (
         "00" + table.loc[table.ORDER.str.len() == 1, "ORDER"]


### PR DESCRIPTION
Tract data tables from 2014 don't contain meta data on the second and third rows like tables from all other years do. This fix covers any table where a row doesn't have a GEOID - these rows should be removed.