### PR TITLE
Update 'latest' release year to 2019

### DIFF
--- a/cenpy/products.py
+++ b/cenpy/products.py
@@ -678,7 +678,7 @@ class ACS(_Product):
     def __init__(self, year="latest"):
         self._cache = dict()
         if year == "latest":
-            year = 2018
+            year = 2019
         if year < 2013:
             raise NotImplementedError(
                 "The requested year {} is too early. "


### PR DESCRIPTION
The latest ACS API year is now 2019.