### PR TITLE
Dynamic _Product._layer_lookup to handle year to year layer id changes, Fixes #90

### DIFF
--- a/cenpy/products.py
+++ b/cenpy/products.py
@@ -83,7 +83,6 @@ class _Product(object):
         """
 
         supported_levels = {
-            'States': 'state',
             'Counties': 'county',
             'Census Blocks': 'block',
             'Census Tracts': 'tract',
@@ -92,7 +91,7 @@ class _Product(object):
         return {
             supported_levels[l._name]: l._id
             for l in self._api.mapservice.layers if
-            l._name in ['Counties', 'Census Tracts', 'Census Blocks']
+            l._name in supported_levels.keys()
         }
 
     def from_place(

--- a/cenpy/products.py
+++ b/cenpy/products.py
@@ -77,16 +77,23 @@ class _Product(object):
     @property
     def _layer_lookup(self):
         """
-        The lookup table relating the layers in the WMS service and the levels
-        supported by this API product.
+        Create lookup table to translate cenpy levels ('county', 'block', 
+        'tract') to layer id. Dynamically create to handle year to year id 
+        changes (naming changes will break) 
         """
-        pass
 
-    @_layer_lookup.getter
-    def _layer_lookup(self):
-        raise NotImplementedError(
-            "This must be implemented on children " "of this class!"
-        )
+        supported_levels = {
+            'States': 'state',
+            'Counties': 'county',
+            'Census Blocks': 'block',
+            'Census Tracts': 'tract',
+        }
+
+        return {
+            supported_levels[l._name]: l._id
+            for l in self._api.mapservice.layers if
+            l._name in ['Counties', 'Census Tracts', 'Census Blocks']
+        }
 
     def from_place(
         self,
@@ -480,8 +487,6 @@ class _Product(object):
 class Decennial2010(_Product):
     """The 2010 Decennial Census from the Census Bueau"""
 
-    _layer_lookup = {"county": 100, "tract": 14, "block": 18}
-
     def __init__(self):
         super(Decennial2010, self).__init__()
         self._api = APIConnection("DECENNIALSF12010")
@@ -672,8 +677,6 @@ class Decennial2010(_Product):
 
 class ACS(_Product):
     """The American Community Survey (5-year vintages) from the Census Bueau"""
-
-    _layer_lookup = {"county": 84, "tract": 8}
 
     def __init__(self, year="latest"):
         self._cache = dict()


### PR DESCRIPTION
Dynamically create `_Product._layer_lookup` from `_Product._api.mapservice.layers`. This fix resolves #90 where layer id changes between 2017 and 2018 created issues at the `county` level. Also allows for future expansion (like #78).

With fix inplace: 
```python
from cenpy import products
acs17 = products.ACS(year=2017)
acs18 = products.ACS(year=2018)
acs19 = products.ACS(year=2019)
dec10 = products.Decennial2010()
#dec20 = products.Decennial2020()

print('acs17', acs17._layer_lookup)
print('acs18', acs18._layer_lookup)
print('acs19', acs19._layer_lookup)
print('dec10', dec10._layer_lookup)
```
> ```python
> acs17 {'tract': 8, 'county': 84}
> acs18 {'tract': 8, 'county': 86}
> acs19 {'tract': 8, 'county': 86}
> dec10 {'tract': 14, 'block': 18, 'county': 100}
> ```