### PR TITLE
Resolve warnings

### DIFF
--- a/cenpy/tiger.py
+++ b/cenpy/tiger.py
@@ -183,7 +183,7 @@ class ESRILayer(object):
         datadict = resp.json()
         if raw:
             return datadict
-        if kwargs.get("returnGeometry", "true") is "false":
+        if kwargs.get("returnGeometry", "true") == "false":
             return pd.DataFrame.from_records(
                 [x["attributes"] for x in datadict["features"]]
             )

--- a/cenpy/tiger.py
+++ b/cenpy/tiger.py
@@ -217,7 +217,7 @@ class ESRILayer(object):
         crs = datadict.pop("spatialReference", None)
         if crs is not None:
             crs = crs.get("latestWkid", crs.get("wkid"))
-            crs = dict(init="epsg:{}".format(crs))
+            crs = 'epsg:{}'.format(crs)
         outdf.crs = crs
         return outdf
 


### PR DESCRIPTION
Resolve SyntaxWarning and FutureWarning (from PyProj).

```python
/cenpy/.venv/lib64/python3.9/site-packages/pyproj/crs/crs.py:53: FutureWarning: '+init=<authority>:<code>' 
syntax is deprecated. '<authority>:<code>' is the preferred initialization method. When making the change, 
be mindful of axis order changes: 
https://pyproj4.github.io/pyproj/stable/gotchas.html#axis-order-changes-in-proj-6
```

```python
/cenpy/cenpy/tiger.py:186: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if kwargs.get("returnGeometry", "true") is "false":
```