### PR TITLE
Migrate to GitHub actions (from #129)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: build
+
+on:
+  push:
+    branches: 
+      - master
+  pull_request:
+    branches: 
+      - master
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Add conda to system path
+      run: |
+        # $CONDA is an environment variable pointing to the root of the miniconda directory
+        echo $CONDA/bin >> $GITHUB_PATH
+    - name: Install dependencies
+      run: |
+        conda install python=${{ matrix.python-version }}
+        conda env update --file environment.yml --name base --prune
+    - name: Test with pytest
+      run: |
+        conda install pytest
+        pytest

--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ CenPy
 .. image:: https://img.shields.io/static/v1.svg?label=documentation&message=latest&color=blueviolet
     :target: https://cenpy-devs.github.io/cenpy
 .. image:: https://github.com/cenpy-devs/cenpy/actions/workflows/build.yml/badge.svg
-    :target: https://github.com/cenpy-devs/cenpy/actions/workflows/build.yml
+    :target: https://github.com/cenpy-devs/cenpy/actions?query=workflow%3A.github%2Fworkflows%2Fbuild.yml
 .. image:: https://img.shields.io/pypi/dm/cenpy.svg
     :target: https://pypi.org/project/cenpy/
 .. image:: https://zenodo.org/badge/36956226.svg

--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@ CenPy
 =====
 .. image:: https://img.shields.io/static/v1.svg?label=documentation&message=latest&color=blueviolet
     :target: https://cenpy-devs.github.io/cenpy
-.. image:: https://travis-ci.org/cenpy-devs/cenpy.svg?branch=master
-    :target: https://travis-ci.org/cenpy-devs/cenpy
+.. image:: https://github.com/cenpy-devs/cenpy/actions/workflows/build.yml/badge.svg
+    :target: https://github.com/cenpy-devs/cenpy/actions/workflows/build.yml
 .. image:: https://img.shields.io/pypi/dm/cenpy.svg
     :target: https://pypi.org/project/cenpy/
 .. image:: https://zenodo.org/badge/36956226.svg

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,13 @@
+name: cenpy
+dependencies:
+  - numpy
+  - scipy
+  - pandas
+  - six
+  - requests
+  - geopandas
+  - rtree
+  - pip
+  - pip:
+    - libpysal
+    - fuzzywuzzy


### PR DESCRIPTION
- Workflow to create conda environment and run pytest on pushes, pull requests and weekly build (midnight on Sunday, UTC)
- Updated build badge on README.rst to point to new CI
- Resolves #129 

Notes:
- Runs only on Python 3.6 to mirror current Travis CI (can be expanded, 3.8 passed)
- Conda environment errors when trying 3.9 (did not look into further)
- See previous builds here: [here](https://github.com/ronnie-llamado/cenpy/actions)