### PR TITLE
Add .gitattributes [skip ci]

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-language=Python


### PR DESCRIPTION
Reclassifies .ipynb as python to alter the repository's language.

Resolves #132