### PR TITLE
Update and streamline GHA CI

### DIFF
--- a/.ci/py36.yml
+++ b/.ci/py36.yml
@@ -1,0 +1,14 @@
+name: tests
+channels:
+  - conda-forge
+dependencies:
+  - python=3.6
+  - geopandas
+  - fuzzywuzzy
+  - libpysal
+  - numpy
+  - pandas
+  - requests
+  - rtree
+  - scipy
+  - six

--- a/.ci/py36.yml
+++ b/.ci/py36.yml
@@ -8,6 +8,7 @@ dependencies:
   - libpysal
   - numpy
   - pandas
+  - pytest
   - requests
   - rtree
   - scipy

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,26 +11,25 @@ on:
     - cron: '0 0 * * 0'
 
 jobs:
-  build-linux:
-    runs-on: ubuntu-latest
+  cenpy-CI:
+    name: CenPy Tests (${{ matrix.os }}, ${{ matrix.environment-file }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       matrix:
-        python-version: [3.6]
+        os: [ubuntu-latest]
+        environment-file: [.ci/py36.yml]
+    
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Add conda to system path
-      run: |
-        # $CONDA is an environment variable pointing to the root of the miniconda directory
-        echo $CONDA/bin >> $GITHUB_PATH
-    - name: Install dependencies
-      run: |
-        conda install python=${{ matrix.python-version }}
-        conda env update --file environment.yml --name base --prune
-    - name: Test with pytest
-      run: |
-        conda install pytest
-        pytest
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      
+      - name: Setup micromamba
+        uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: ${{ matrix.environment-file }}
+          micromamba-version: 'latest'
+      
+      - name: Test with pytest
+        shell: bash -l {0}
+        run: pytest -v cenpy

--- a/environment.yml
+++ b/environment.yml
@@ -1,13 +1,20 @@
-name: cenpy
+name: notebooks-environment
+channels:
+  - conda-forge
 dependencies:
-  - numpy
-  - scipy
-  - pandas
-  - six
-  - requests
+  - python=3.6
+  - contextily
   - geopandas
+  - fuzzywuzzy
+  - libpysal
+  - matplotlib
+  - numpy
+  - osmnx
+  - pandas
+  - requests
   - rtree
+  - scipy
+  - segregation
+  - six
   - pip
-  - pip:
-    - libpysal
-    - fuzzywuzzy
+    - git+https://github.com/cenpy-devs/cenpy.git@master


### PR DESCRIPTION
This PR build on #130 by:
* updating and streaming the syntax on `build.yml` to enable stress-free extensibility
* utilizing [`micromamba`](https://github.com/mamba-org/provision-with-micromamba) for environment creation for quicker set up times (eg. see [here](https://github.com/pysal/spaghetti/pull/614))
  * cut by ~.5x ([Install dependencies](https://github.com/cenpy-devs/cenpy/runs/2429394512?check_suite_focus=true#step:5:1) vs. [Setup micromamba](https://github.com/cenpy-devs/cenpy/runs/2440153134?check_suite_focus=true#step:3:1))
* creating a dedicated directory for CI environments that can be extended
* retaining/updating `environment.yml` so that it can be used for [`binder`](https://mybinder.org) instances