### PR TITLE
Extend continuous integration testing matrix

### DIFF
--- a/.ci/py35.yml
+++ b/.ci/py35.yml
@@ -1,0 +1,15 @@
+name: tests
+channels:
+  - conda-forge
+dependencies:
+  - python=3.5
+  - geopandas
+  - fuzzywuzzy
+  - libpysal
+  - numpy
+  - pandas
+  - pytest
+  - requests
+  - rtree
+  - scipy
+  - six

--- a/.ci/py37.yml
+++ b/.ci/py37.yml
@@ -2,7 +2,7 @@ name: tests
 channels:
   - conda-forge
 dependencies:
-  - python=3.5
+  - python=3.7
   - geopandas
   - fuzzywuzzy
   - libpysal

--- a/.ci/py38.yml
+++ b/.ci/py38.yml
@@ -1,0 +1,15 @@
+name: tests
+channels:
+  - conda-forge
+dependencies:
+  - python=3.8
+  - geopandas
+  - fuzzywuzzy
+  - libpysal
+  - numpy
+  - pandas
+  - pytest
+  - requests
+  - rtree
+  - scipy
+  - six

--- a/.ci/py39.yml
+++ b/.ci/py39.yml
@@ -1,0 +1,15 @@
+name: tests
+channels:
+  - conda-forge
+dependencies:
+  - python=3.9
+  - geopandas
+  - fuzzywuzzy
+  - libpysal
+  - numpy
+  - pandas
+  - pytest
+  - requests
+  - rtree
+  - scipy
+  - six

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        environment-file: [.ci/py36.yml, .ci/py37.yml, .ci/py38.yml]
+        environment-file: [.ci/py36.yml, .ci/py37.yml, .ci/py38.yml, .ci/py39.yml]
     
     steps:
       - name: Checkout repo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        environment-file: [.ci/py36.yml, .ci/py37.yml]
+        environment-file: [.ci/py36.yml, .ci/py37.yml, .ci/py38.yml]
     
     steps:
       - name: Checkout repo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [macos-latest, ubuntu-latest]
         environment-file: [.ci/py36.yml, .ci/py37.yml, .ci/py38.yml, .ci/py39.yml]
     
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        environment-file: [.ci/py36.yml]
+        environment-file: [.ci/py35.yml, .ci/py36.yml]
     
     steps:
       - name: Checkout repo

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
         environment-file: [.ci/py36.yml, .ci/py37.yml, .ci/py38.yml, .ci/py39.yml]
     
     steps:
@@ -30,6 +30,12 @@ jobs:
           environment-file: ${{ matrix.environment-file }}
           micromamba-version: 'latest'
       
-      - name: Test with pytest
+      - name: Test with pytest - bash
         shell: bash -l {0}
         run: pytest -v cenpy
+        if: matrix.os != 'windows-latest'
+      
+      - name: Test with pytest - powershell
+        shell: powershell
+        run: pytest -v cenpy
+        if: matrix.os == 'windows-latest'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        environment-file: [.ci/py35.yml, .ci/py36.yml]
+        environment-file: [.ci/py36.yml, .ci/py37.yml]
     
     steps:
       - name: Checkout repo

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ CenPy
 =====
 .. image:: https://img.shields.io/static/v1.svg?label=documentation&message=latest&color=blueviolet
     :target: https://cenpy-devs.github.io/cenpy
-.. image:: https://github.com/cenpy-devs/cenpy/actions/workflows/build.yml/badge.svg
+.. image:: https://github.com/cenpy-devs/cenpy/workflows/.github/workflows/build.yml/badge.svg
     :target: https://github.com/cenpy-devs/cenpy/actions?query=workflow%3A.github%2Fworkflows%2Fbuild.yml
 .. image:: https://img.shields.io/pypi/dm/cenpy.svg
     :target: https://pypi.org/project/cenpy/

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,10 @@
 from setuptools import setup
 import os
 
+package = "spaghetti"
+
 basepath = os.path.dirname(__file__)
-init = os.path.join(basepath, "cenpy/__init__.py")
+init = os.path.join(basepath, f"{package}/__init__.py")
 
 with open(init, "r") as initfile:
     firstline = initfile.readline()
@@ -18,18 +20,18 @@ with open(os.path.join(basepath, "requirements.txt"), "r") as reqfile:
 reqs = [req.strip() for req in reqs]
 
 setup(
-    name="cenpy",
+    name=package,
     version=init_version,
     description="Explore and download data from Census APIs",
     long_description=long_description,
-    url="https://github.com/cenpy-devs/cenpy",
+    url=f"https://github.com/{package}-devs/{package}",
     author="Levi John Wolf",
     author_email="levi.john.wolf@gmail.com",
     license="3-Clause BSD",
     python_requires=">=3.6",
-    packages=["cenpy"],
+    packages=[package],
     install_requires=reqs,
-    package_data={"cenpy": ["stfipstable.csv"]},
+    package_data={package: ["stfipstable.csv"]},
     zip_safe=False,
     classifiers=[
         "Development Status :: 5 - Production/Stable",

--- a/setup.py
+++ b/setup.py
@@ -31,4 +31,18 @@ setup(
     install_requires=reqs,
     package_data={"cenpy": ["stfipstable.csv"]},
     zip_safe=False,
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Science/Research",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Education",
+        "Topic :: Scientific/Engineering",
+        "Topic :: Scientific/Engineering :: GIS",
+        "License :: OSI Approved :: BSD License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -2,31 +2,33 @@ from setuptools import setup
 import os
 
 basepath = os.path.dirname(__file__)
-init = os.path.join(basepath, 'cenpy/__init__.py')
+init = os.path.join(basepath, "cenpy/__init__.py")
 
-with open(init, 'r') as initfile:
+with open(init, "r") as initfile:
     firstline = initfile.readline()
-init_version = firstline.split('=')[-1].strip()
-init_version = init_version.replace("'","")
+init_version = firstline.split("=")[-1].strip()
+init_version = init_version.replace("'", "")
 
-with open(os.path.join(basepath, 'README.rst'), 'r') as readme:
+with open(os.path.join(basepath, "README.rst"), "r") as readme:
     long_description = readme.readlines()
-long_description = ''.join(long_description)
+long_description = "".join(long_description)
 
-with open(os.path.join(basepath, 'requirements.txt'), 'r') as reqfile:
+with open(os.path.join(basepath, "requirements.txt"), "r") as reqfile:
     reqs = reqfile.readlines()
 reqs = [req.strip() for req in reqs]
 
-setup(name='cenpy',
-      version=init_version,
-      description='Explore and download data from Census APIs',
-      long_description=long_description,
-      url='https://github.com/cenpy-devs/cenpy',
-      author='Levi John Wolf',
-      author_email='levi.john.wolf@gmail.com',
-      license='3-Clause BSD',
-      python_requires='>=3.5',
-      packages=['cenpy'],
-      install_requires=reqs,
-      package_data={'cenpy': ['stfipstable.csv']},
-      zip_safe=False)
+setup(
+    name="cenpy",
+    version=init_version,
+    description="Explore and download data from Census APIs",
+    long_description=long_description,
+    url="https://github.com/cenpy-devs/cenpy",
+    author="Levi John Wolf",
+    author_email="levi.john.wolf@gmail.com",
+    license="3-Clause BSD",
+    python_requires=">=3.6",
+    packages=["cenpy"],
+    install_requires=reqs,
+    package_data={"cenpy": ["stfipstable.csv"]},
+    zip_safe=False,
+)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 import os
 
-package = "spaghetti"
+package = "cenpy"
 
 basepath = os.path.dirname(__file__)
 init = os.path.join(basepath, f"{package}/__init__.py")


### PR DESCRIPTION
The PR addresses #135.
* adds Python 3.{7,8,9} and macOS & Windows to the testing matrix
* drops support for 3.5 from `setup.py`
  * seems `rtree` is [no good](https://github.com/cenpy-devs/cenpy/runs/2441522597?check_suite_focus=true#step:3:53) for Python 3.5