### PR TITLE
Add requests.session to REST classes

### DIFF
--- a/cenpy/api.py
+++ b/cenpy/api.py
@@ -1,0 +1,12 @@
+
+import requests
+
+
+class RestApiBase:
+
+    def __init__(self, session=None):
+        self._session = session if session else requests.session()
+
+    def _get(self, url, params={}):
+        response = self._session.get(url, params=params)
+        return response


### PR DESCRIPTION
Add a `requests.session` to `APIConnection`, `TigerConnection` and `ESRILayer`. Creates persistent HTTP connection to be reused when requesting from the same domain.  Currently each GET request opens a new connections, transacts and then closes the connection.

Closes #140