### PR TITLE
Fix breaking issue in tiger query processing

### DIFF
--- a/cenpy/__init__.py
+++ b/cenpy/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.0post3"
+__version__ = "1.0.1"
 __author__ = "Levi John Wolf levi.john.wolf@gmail.com"
 
 from . import explorer

--- a/cenpy/products.py
+++ b/cenpy/products.py
@@ -191,12 +191,12 @@ class _Product(object):
 
         env_layer = self._api.mapservice.layers[env_name.name]
         if place_type == "County Subdivision":
-            placer = "STATE={} AND COUSUB={}".format(
+            placer = "STATE='{}' AND COUSUB='{}'".format(
                 placerow.STATEFP, placerow.TARGETFP
             )
         else:
 
-            placer = "STATE={} AND PLACE={}".format(placerow.STATEFP, placerow.TARGETFP)
+            placer = "STATE='{}' AND PLACE='{}'".format(placerow.STATEFP, placerow.TARGETFP)
         env = env_layer.query(where=placer)
 
         print(
@@ -348,7 +348,7 @@ class _Product(object):
             cache_name = layername_match.target.lstrip("(ESRILayer) ")
         row = self._cache[cache_name].loc[item_name.name]
         return layer.query(
-            where="GEOID={}".format(row.GEOID), geometryPrecision=geometry_precision
+            where="GEOID='{}'".format(row.GEOID), geometryPrecision=geometry_precision
         )
 
     def _from_name(

--- a/cenpy/products.py
+++ b/cenpy/products.py
@@ -219,7 +219,7 @@ class _Product(object):
             replace_missing=replace_missing,
         )
         if strict_within:
-            geoms = geopandas.sjoin(geoms, env[["geometry"]], how="inner", op="within")
+            geoms = geopandas.sjoin(geoms, env[["geometry"]], how="inner", predicate="within")
         if return_bounds:
             return (geoms, data, env)
         return geoms, data
@@ -258,7 +258,7 @@ class _Product(object):
         # filter the records by a strict "within" query if needed
         if strict_within:
             involved = geopandas.sjoin(
-                involved, env[["geometry"]], how="inner", op="within"
+                involved, env[["geometry"]], how="inner", predicate="within"
             )
 
         # Construct a "query" translator between the GeoAPI and the Census API
@@ -386,7 +386,7 @@ class _Product(object):
             replace_missing=replace_missing,
         )
         if strict_within:
-            geoms = geopandas.sjoin(geoms, env[["geometry"]], how="inner", op="within")
+            geoms = geopandas.sjoin(geoms, env[["geometry"]], how="inner", predicate="within")
         if return_bounds:
             return geoms, data, env
         return geoms, data

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ init = os.path.join(basepath, f"{package}/__init__.py")
 with open(init, "r") as initfile:
     firstline = initfile.readline()
 init_version = firstline.split("=")[-1].strip()
-init_version = init_version.replace("'", "")
+init_version = init_version.replace('"', '')
 
 with open(os.path.join(basepath, "README.rst"), "r") as readme:
     long_description = readme.readlines()


### PR DESCRIPTION
I think that the ESRI API may have switched to "strict" processing of strings, so that rather than accepting something like `STATE = 06`, it now needs `STATE = '06'`. This might also be something changing between python versions. 

But, properly generating (or consuming) this query string for the ESRI mapservice layers seems to be the issue.  