### PR TITLE
fix: Switch 'is not' to '!=' for correctness and avoid SyntaxWarning

### DIFF
--- a/cenpy/moe/pseudo_utils.py
+++ b/cenpy/moe/pseudo_utils.py
@@ -165,7 +165,7 @@ def pseudo(
         zero_ests = ests.copy()
         for col in zero_ests.columns:
             zero_ests[col] = base.zero_bool
-    elif ignore_zeros is not "no":  # to catch bad parameter values
+    elif ignore_zeros != "no":  # to catch bad parameter values
         raise Exception("ignore_zeros must be 'all', 'partial' or 'no'")
 
     # setup output array

--- a/cenpy/remote.py
+++ b/cenpy/remote.py
@@ -221,7 +221,7 @@ class APIConnection:
             assert all([col in df.columns for col in cols])
             if convert_numeric:
                 df = df.infer_objects()
-            if index is not "":
+            if index != "":
                 df.index = df[index]
             return df
         except (ValueError, JSONDecodeError):


### PR DESCRIPTION
Fixes #165 .

Eliminate a `SyntaxWarning` on Python>=3.12.